### PR TITLE
Updates for MSYS2 Upgrade to OpenSSL 3

### DIFF
--- a/.github/workflows/mswin.yml
+++ b/.github/workflows/mswin.yml
@@ -12,6 +12,8 @@ jobs:
   mswin:
     name: >-
       mswin vcpkg tools
+    env:
+      FORCE_UPDATE: true
     runs-on: windows-2022
     strategy:
       fail-fast: false

--- a/.github/workflows/windows-build-tools.yml
+++ b/.github/workflows/windows-build-tools.yml
@@ -49,6 +49,7 @@ jobs:
       matrix:
         include:
           - { gcc: mingw64    , ruby: mingw }
+          - { gcc: mingw64-3.0, ruby: mingw }
           - { gcc: ucrt64     , ruby: ucrt  }
           - { gcc: ucrt64-3.0 , ruby: 3.2   }
     steps:

--- a/.github/workflows/windows-build-tools.yml
+++ b/.github/workflows/windows-build-tools.yml
@@ -12,6 +12,8 @@ jobs:
   msys2:
     name: >-
       msys2 tools
+    # env:
+    #  FORCE_UPDATE: true
     runs-on: windows-2022
     strategy:
       fail-fast: false
@@ -43,6 +45,8 @@ jobs:
   gcc:
     name: >-
       ${{ matrix.gcc }} gcc
+    env:
+      FORCE_UPDATE: true
     runs-on: windows-2022
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Below summarizes the default MSYS2 installations on Actions Windows images:
 
 ### Notes
 
-Four package files are stored in a GitHub release, and are used by
+Six package files are stored in a GitHub release, and are used by
 [ruby/setup-ruby](https://github.com/ruby/setup-ruby).  They are:
 
 * **`msys2.7z`** The base msys2 installation on Actions Windows images contains a minimal
@@ -30,14 +30,23 @@ updated files to the 7z.  All Ruby Windows releases from version 2.4 and later u
 tools.
 
 * **`mingw64.7z`** This contains the mingw64 gcc chain and any packages needed to build
-Ruby.  Normal Ruby Windows releases from version 2.4 thru 3.0 use these tools.
+Ruby.  This has OpenSSL 1.1.1 installed, as of 19-Jan-2023, 1.1.1.s.  Normal Ruby Windows
+releases from version 2.4 thru 3.0 use these tools.
+
+* **`mingw64-3.0.7z`** This contains the mingw64 gcc chain and any packages needed to build
+Ruby.  The MSYS2 OpenSSL 3.0.z package is installed.  The mingw Ruby master build is the
+only build that uses this.
 
 * **`ucrt64.7z`** This contains the ucrt64 gcc chain and any packages needed to build
-Ruby.  Normal Ruby Windows releases from version 3.1 and later use these tools.
+Ruby.  This has OpenSSL 1.1.1 installed, as of 19-Jan-2023, 1.1.1.s.  Ruby version 3.1 is
+the only release that uses this.
+
+* **`ucrt64-3.0.7z`** This contains the ucrt64 gcc chain and any packages needed to build
+Ruby. The MSYS2 OpenSSL 3.0.z package is installed.  Ruby 3.2, head, & ucrt builds use this.
 
 * **`mswin.7z`** This contains files needed to compile Windows Ruby mswin builds. It contains
-libffi, libyaml, openssl, readline, and zlib, built with the Microsoft vcpkg system.
-
+libffi, libyaml, openssl, readline, and zlib, built with the Microsoft vcpkg system.  This
+contains OpenSSL 3.0.z.
 
 The code installs the packages with [ruby/setup-ruby](https://github.com/ruby/setup-ruby),
 then updates the MSYS2 and vcpkg packages.  If any packages have been updated, it creates

--- a/create_mswin_pkg.rb
+++ b/create_mswin_pkg.rb
@@ -59,7 +59,7 @@ module CreateMswin
 
       Dir.chdir VCPKG do |d|
         update_info = %x(./vcpkg update)
-        if update_info.include? 'No packages need updating'
+        if update_info.include?('No packages need updating') && !ENV.key?('FORCE_UPDATE')
           STDOUT.syswrite "\n#{GRN}No packages need updating#{RST}\n\n"
           exit 0
         else

--- a/create_msys2_pkg.rb
+++ b/create_msys2_pkg.rb
@@ -96,7 +96,7 @@ module CreateMSYS2Tools
 
       gpg_files = Dir["#{MSYS2_ROOT}/etc/pacman.d/gnupg/*"].count { |fn| File.file? fn }
 
-      if current_pkgs == updated_pkgs && !updated_keys
+      if current_pkgs == updated_pkgs && !updated_keys && !ENV.key?('FORCE_UPDATE')
         STDOUT.syswrite "\n** No update to MSYS2 tools needed **\n\n"
         exit 0
       else


### PR DESCRIPTION
Adds a 'mingw64-3.0.7z' archive file, which is only used with the Ruby master mingw build.

Other updates for separate archives for building with both OpenSSL 1.1.1 (older Rubies) and OpenSSL 3.

