### PR TITLE
Fixup #2 for OpenSSL 3

### DIFF
--- a/create_gcc_pkg.rb
+++ b/create_gcc_pkg.rb
@@ -128,8 +128,10 @@ module CreateMingwGCC
 
       pkgs = (base_gcc + base_ruby).unshift('').join " #{PKG_PRE}"
 
-      SSL_3_SAVE_FILES.each do |fn|
-        FileUtils.remove_file "#{MSYS2_PKG}/#{fn}" if File.exist? "#{MSYS2_PKG}/#{fn}"
+      unless PKG_NAME.end_with? '-3.0'
+        SSL_3_SAVE_FILES.each do |fn|
+          FileUtils.remove_file "#{MSYS2_PKG}/#{fn}" if File.exist? "#{MSYS2_PKG}/#{fn}"
+        end
       end
 
       # May not be needed, but...


### PR DESCRIPTION
Only delete OpenSSL 3 dll's when updating OpenSSL 1.1.1. gcc packages.