### PR TITLE
Fewer concurrent jobs

### DIFF
--- a/.github/workflows/windows-build-tools.yml
+++ b/.github/workflows/windows-build-tools.yml
@@ -42,7 +42,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         timeout-minutes: 10
 
-  gcc:
+  gcc-mingw:
+    if: ${{ always() }}
+    needs: msys2
     name: >-
       ${{ matrix.gcc }} gcc
     #env:
@@ -54,6 +56,34 @@ jobs:
         include:
           - { gcc: mingw64    , ruby: '3.0' }
           - { gcc: mingw64-3.0, ruby: mingw }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+        timeout-minutes: 7
+
+      - name: Update ${{ matrix.gcc }} gcc 7z and Upload
+        run:  ruby create_gcc_pkg.rb ${{ matrix.gcc }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        timeout-minutes: 13
+
+  gcc-ucrt:
+    if: ${{ always() }}
+    needs: gcc-mingw
+    name: >-
+      ${{ matrix.gcc }} gcc
+    #env:
+    #  FORCE_UPDATE: true
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - { gcc: ucrt64     , ruby: 3.1   }
           - { gcc: ucrt64-3.0 , ruby: ucrt  }
     steps:
@@ -70,4 +100,5 @@ jobs:
         run:  ruby create_gcc_pkg.rb ${{ matrix.gcc }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        timeout-minutes: 10
+        timeout-minutes: 13
+

--- a/common.rb
+++ b/common.rb
@@ -326,11 +326,13 @@ module Common
 
     ignore = ignore ? "--ignore #{ignore}" : nil
 
-    exec_check 'Updating all installed packages', "#{PACMAN} -Syuu  --noconfirm #{ignore}"
+    cmd = "#{PACMAN} -Syuu --disable-download-timeout --noconfirm #{ignore}"
+
+    exec_check 'Updating all installed packages', cmd
 
     system 'taskkill /f /fi "MODULES eq msys-2.0.dll"'
 
-    exec_check 'Updating all installed packages (2nd pass)', "#{PACMAN} -Syuu  --noconfirm #{ignore}"
+    exec_check 'Updating all installed packages (2nd pass)', cmd
 
     system 'taskkill /f /fi "MODULES eq msys-2.0.dll"'
 


### PR DESCRIPTION
Previously, all five jobs could run concurrently.  Recently, there have been a lot of timeout errors when downloading files from the MSYS2 servers/mirrors.

They may be limiting concurrent downloads.  Regardless, split up jobs so only two jobs run concurrently.