### PR TITLE
Support clangarm64 environment

### DIFF
--- a/.github/workflows/windows-build-tools.yml
+++ b/.github/workflows/windows-build-tools.yml
@@ -11,17 +11,24 @@ on:
 jobs:
   msys2:
     name: >-
-      msys2 tools
+      ${{ matrix.name }} tools
     #env:
     #  FORCE_UPDATE: true
-    runs-on: windows-2022
+    permissions:
+      contents: write
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      matrix:
+        include:
+          - { os: windows-2022, ruby: ucrt, name: msys2, type: ucrt64, windows-toolchain: default }
+          - { os: windows-11-arm, ruby: 3.4, name: msys2-arm64, type: clangarm64, windows-toolchain: none }
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Copy msys2 files to temp dir
+        if: matrix.windows-toolchain == 'default'
         run:  |
           $temp = $env:RUNNER_TEMP
           md $temp\msys64
@@ -30,16 +37,33 @@ jobs:
           xcopy C:\msys64 $temp\msys64 /s /q
         timeout-minutes: 15
 
+      - name: Install msys2
+        if: matrix.windows-toolchain == 'none'
+        run:  |
+          (New-Object System.Net.WebClient).DownloadFile("https://repo.msys2.org/distrib/msys2-x86_64-latest.sfx.exe", "msys2-x86_64-latest.sfx.exe")
+          (New-Object System.Net.WebClient).DownloadFile("https://repo.msys2.org/distrib/msys2-x86_64-latest.sfx.exe.sig", "msys2-x86_64-latest.sfx.exe.sig")
+          gpg --keyserver keyserver.ubuntu.com --recv "0EBF 782C 5D53 F7E5 FB02  A667 46BD 761F 7A49 B0EC"
+          gpg --verify msys2-x86_64-latest.sfx.exe.sig
+
+          .\msys2-x86_64-latest.sfx.exe -y -oC:\
+
+          C:\msys64\msys2_shell.cmd -defterm -here -no-start -${{ matrix.type }}
+
+          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\msys64\${{ matrix.type }}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        timeout-minutes: 15
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ucrt
+          ruby-version: ${{ matrix.ruby }}
+          windows-toolchain: ${{ matrix.windows-toolchain }}
         timeout-minutes: 7
 
       - name: Update msys2 tools 7z and Upload
-        run:  ruby create_msys2_pkg.rb
+        run:  ruby create_msys2_pkg.rb ${{ matrix.name }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         timeout-minutes: 10
 
   gcc-mingw:
@@ -49,6 +73,8 @@ jobs:
       ${{ matrix.gcc }} gcc
     #env:
     #  FORCE_UPDATE: true
+    permissions:
+      contents: write
     runs-on: windows-2022
     strategy:
       fail-fast: false
@@ -69,16 +95,18 @@ jobs:
       - name: Update ${{ matrix.gcc }} gcc 7z and Upload
         run:  ruby create_gcc_pkg.rb ${{ matrix.gcc }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         timeout-minutes: 13
 
   gcc-ucrt:
     if: ${{ always() }}
-    needs: gcc-mingw
+    needs: msys2
     name: >-
       ${{ matrix.gcc }} gcc
     #env:
     #  FORCE_UPDATE: true
+    permissions:
+      contents: write
     runs-on: windows-2022
     strategy:
       fail-fast: false
@@ -99,6 +127,37 @@ jobs:
       - name: Update ${{ matrix.gcc }} gcc 7z and Upload
         run:  ruby create_gcc_pkg.rb ${{ matrix.gcc }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+        timeout-minutes: 13
+
+  gcc-clangarm64:
+    if: ${{ always() }}
+    needs: msys2
+    name: >-
+      ${{ matrix.gcc }} gcc
+    #env:
+    #  FORCE_UPDATE: true
+    permissions:
+      contents: write
+    runs-on: windows-11-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { gcc: clangarm64-3.0 , ruby: 3.4 }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+        timeout-minutes: 7
+
+      - name: Update ${{ matrix.gcc }} gcc 7z and Upload
+        run:  ruby create_gcc_pkg.rb ${{ matrix.gcc }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         timeout-minutes: 13
 

--- a/.github/workflows/windows-build-tools.yml
+++ b/.github/workflows/windows-build-tools.yml
@@ -21,43 +21,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: windows-2022, ruby: ucrt, name: msys2, type: ucrt64, windows-toolchain: default }
-          - { os: windows-11-arm, ruby: 3.4, name: msys2-arm64, type: clangarm64, windows-toolchain: none }
+          - { os: windows-2022, ruby: ucrt, name: msys2 }
+          - { os: windows-11-arm, ruby: 3.4, name: msys2-arm64 }
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Copy msys2 files to temp dir
-        if: matrix.windows-toolchain == 'default'
         run:  |
-          $temp = $env:RUNNER_TEMP
-          md $temp\msys64
-          # copy current msys2 to temp folder, needed to determine what files to include
-          # in zip file (only newer files)
-          xcopy C:\msys64 $temp\msys64 /s /q
-        timeout-minutes: 15
-
-      - name: Install msys2
-        if: matrix.windows-toolchain == 'none'
-        run:  |
-          (New-Object System.Net.WebClient).DownloadFile("https://repo.msys2.org/distrib/msys2-x86_64-latest.sfx.exe", "msys2-x86_64-latest.sfx.exe")
-          (New-Object System.Net.WebClient).DownloadFile("https://repo.msys2.org/distrib/msys2-x86_64-latest.sfx.exe.sig", "msys2-x86_64-latest.sfx.exe.sig")
-          gpg --keyserver keyserver.ubuntu.com --recv "0EBF 782C 5D53 F7E5 FB02  A667 46BD 761F 7A49 B0EC"
-          gpg --verify msys2-x86_64-latest.sfx.exe.sig
-
-          .\msys2-x86_64-latest.sfx.exe -y -oC:\
-
-          C:\msys64\msys2_shell.cmd -defterm -here -no-start -${{ matrix.type }}
-
-          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          echo "C:\msys64\${{ matrix.type }}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          if (Test-Path -LiteralPath C:\msys64 -PathType Container) {
+            $temp = $env:RUNNER_TEMP
+            md $temp\msys64
+            # copy current msys2 to temp folder, needed to determine what files to include
+            # in zip file (only newer files)
+            xcopy C:\msys64 $temp\msys64 /s /q
+          }
         timeout-minutes: 15
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          windows-toolchain: ${{ matrix.windows-toolchain }}
         timeout-minutes: 7
 
       - name: Update msys2 tools 7z and Upload

--- a/README.md
+++ b/README.md
@@ -16,25 +16,30 @@ Below summarizes the default MSYS2 installations on Actions Windows images:
 
 | Actions<br/>Image  |  MSYS<br/>Base | MSYS<br/>Build Tools | mingw64<br/>gcc & tools | mingw64<br/>packages | ucrt64<br/>gcc & tools | ucrt64<br/>packages |
 |--------------------|:--------------:|:--------------------:|:-----------------------:|:--------------------:|:----------------------:|:-------------------:|
+| **11-arm**         | No  | No  | No  | No  | No  | No |
 | **2022 and later** | Yes | No  | No  | No  | No  | No |
 | **2016, 2019**     | Yes | Yes | Yes | Some | No  | No  |
 
 ### Notes
 
-Six package files are stored in a GitHub release, and are used by
+Eight package files are stored in a GitHub release, and are used by
 [ruby/setup-ruby](https://github.com/ruby/setup-ruby).  They are:
 
 * **`msys2.7z`** The base msys2 installation on Actions Windows images contains a minimal
 set of bash tools, and no shared build tools.  Code updates the MSYS2 files, and saves only
-updated files to the 7z.  All Ruby Windows releases from version 2.4 and later use these
+updated files to the 7z.  All Ruby Windows x64 releases from version 2.4 and later use these
 tools.
+
+* **`msys2-arm64.7z`** The base msys2 installation on Actions Windows images contains a minimal
+set of bash tools, and no shared build tools.  Code saves complate base MSYS2 files to the 7z.
+All Ruby Windows arm64 releases from version 3.4 and later use these tools.
 
 * **`mingw64.7z`** This contains the mingw64 gcc chain and any packages needed to build
 Ruby.  This has OpenSSL 1.1.1 installed, as of 26-Apr-2024, 1.1.1.w.  Normal Ruby Windows
 releases from version 2.4 thru 3.0 use these tools.
 
 * **`mingw64-3.0.7z`** This contains the mingw64 gcc chain and any packages needed to build
-Ruby.  The MSYS2 OpenSSL 3.3.z package is installed.  The mingw Ruby master build is the
+Ruby.  The MSYS2 OpenSSL 3.y.z package is installed.  The mingw Ruby master build is the
 only build that uses this.
 
 * **`ucrt64.7z`** This contains the ucrt64 gcc chain and any packages needed to build
@@ -42,7 +47,11 @@ Ruby.  This has OpenSSL 1.1.1 installed, as of 26-Apr-2024, 1.1.1.w.  Ruby versi
 the only release that uses this.
 
 * **`ucrt64-3.0.7z`** This contains the ucrt64 gcc chain and any packages needed to build
-Ruby. The MSYS2 OpenSSL 3.3.z package is installed.  Ruby 3.2, head, & ucrt builds use this.
+Ruby. The MSYS2 OpenSSL 3.y.z package is installed.  Ruby 3.2, head, & ucrt builds use this.
+
+* **`clangarm64-3.0.7z`** This contains the clangarm64 gcc chain and any packages needed to build
+Ruby. The MSYS2 OpenSSL 3.y.z package is installed.  Ruby 3.4 and head builds on windows arm64
+use this.
 
 * **`mswin.7z`** This contains files needed to compile Windows Ruby mswin builds. It contains
 libffi, libyaml, openssl, readline, and zlib, built with the Microsoft vcpkg system.  This

--- a/common.rb
+++ b/common.rb
@@ -34,16 +34,9 @@ module Common
   PACMAN     = 'C:/msys64/usr/bin/pacman.exe'
   BASH       = 'C:/msys64/usr/bin/bash.exe'
 
-  SSL_3_SAVE_FILES = %w[
-    bin/libcrypto-3-x64.dll
-    bin/libssl-3-x64.dll
-    etc/ssl/openssl.cnf
-  ]
-
   def gh_api_graphql(http, query)
     body = {}
     body["query"] = query
-    response = nil
 
     req = Net::HTTP::Post.new '/gh_api_graphql'
     req['Authorization'] = "Bearer #{TOKEN}"
@@ -315,12 +308,12 @@ module Common
     system 'taskkill /f /fi "MODULES eq msys-2.0.dll"'
 
     STDOUT.syswrite "#{str}\n#{END_GROUP}"
-    
+
     str.match?(/new signatures:|signatures cleaned:/) ? true : nil
   end
 
   def pacman_syuu(ignore = nil)
-    
+
     usr_bin = "#{MSYS2_ROOT}/usr/bin"
 
     exit 1 unless system "#{usr_bin}/sed -i 's/^CheckSpace/#CheckSpace/g' C:/msys64/etc/pacman.conf"

--- a/create_gcc_pkg.rb
+++ b/create_gcc_pkg.rb
@@ -38,14 +38,26 @@ module CreateMingwGCC
         ['mingw64', 'mingw-w64-x86_64-']
       when 'mingw32'
         ['mingw32', 'mingw-w64-i686-']
+      when 'clangarm64'
+        ['clangarm64', 'mingw-w64-clang-aarch64-']
       else
-        STDOUT.syswrite "Invalid package type, must be ucrt64, mingw64, or mingw32\n"
+        STDOUT.syswrite "Invalid package type, must be ucrt64, mingw64, mingw32, or clangarm64\n"
         exit 1
       end
 
     MSYS2_PKG = "#{MSYS2_ROOT}/#{PKG_DIR}"
-    
-    SSL_1_DLLS = %w[bin/libcrypto-1_1-x64.dll bin/libssl-1_1-x64.dll]
+
+    SSL_1_DLLS = if PKG_DIR == 'clangarm64'
+                   %w[bin/libcrypto-1_1.dll bin/libssl-1_1.dll]
+                 else
+                   %w[bin/libcrypto-1_1-x64.dll bin/libssl-1_1-x64.dll]
+                 end
+
+    SSL_3_SAVE_FILES = if PKG_DIR == 'clangarm64'
+                         %w[bin/libcrypto-3.dll bin/libssl-3.dll etc/ssl/openssl.cnf]
+                       else
+                         %w[bin/libcrypto-3-x64.dll bin/libssl-3-x64.dll etc/ssl/openssl.cnf]
+                       end
 
     def add_ri2_key
       # appveyor ri2 package signing key
@@ -85,11 +97,9 @@ module CreateMingwGCC
       pkg_name = "openssl-3.0.7-1-any.pkg.tar.zst"
       pkg = "https://github.com/oneclick/rubyinstaller2-packages/releases/download/ci.ri2/#{PKG_PRE}#{pkg_name}"
       pkg_sig = "#{pkg}.sig"
-      old_dlls = %w[libcrypto-1_1-x64.dll libssl-1_1-x64.dll]
-      dll_root = "#{MSYS2_ROOT}/#{PKG_DIR}/bin"
 
       # save previous dll files so we can copy back into folder
-      old_dlls.each { |fn| FileUtils.cp "#{dll_root}/#{fn}", "." }
+      SSL_1_DLLS.each { |fn| FileUtils.cp "#{MSYS2_PKG}/#{fn}", "." }
 
       download pkg    , "./#{PKG_PRE}#{pkg_name}"
       download pkg_sig, "./#{PKG_PRE}#{pkg_name}.sig"
@@ -98,11 +108,7 @@ module CreateMingwGCC
       exec_check "Install OpenSSL Upgrade", "pacman.exe -Udd --noconfirm --noprogressbar #{PKG_PRE}#{pkg_name}"
 
       # copy previous dlls back into MSYS2 folder
-      old_dlls.each do |fn|
-        unless File.exist? "#{dll_root}/#{fn}"
-          FileUtils.cp fn , "#{dll_root}/#{fn}"
-        end
-      end
+      SSL_1_DLLS.each { |fn| FileUtils.cp_r File.basename(fn) , "#{MSYS2_PKG}/#{fn}" }
     end
 
     # Below files are part of the 'ca-certificates' package, they are not
@@ -142,7 +148,7 @@ module CreateMingwGCC
       # Note that OpenSSL may need to be ignored
       if PKG_NAME.end_with?('-3.0')
         pacman_syuu
-     else
+      else
         pacman_syuu
       end
 
@@ -240,6 +246,10 @@ module CreateMingwGCC
       else
         STDOUT.syswrite "\n#{GRN}** Creating and Uploading #{PKG_DIR} gcc tools 7z **#{RST}\n\n"
       end
+
+      exec_check "Remove all uninstalled packages" , "#{BASH} -c \"paccache -r -f -u -k0\""
+      exec_check "Keep the newest for all other packages" , "#{BASH} -c \"paccache -r -f -k1\""
+      exec_check "Remove all cached packages" , "#{PACMAN} -Scc --noconfirm"
 
       copy_to_temp
 

--- a/create_mswin_pkg.rb
+++ b/create_mswin_pkg.rb
@@ -60,7 +60,7 @@ module CreateMswin
       Dir.chdir VCPKG do |d|
 
         install_info = %x(./vcpkg install  #{PACKAGES} --triplet=x64-windows --dry-run)
-        
+
         installed_packages = install_info.include?('The following packages will be built and installed')
 
         exec_check "Installing #{PACKAGES}",
@@ -101,7 +101,7 @@ module CreateMswin
 
     def run
       generate_package_files
-      
+
       copy_ssl_files
 
       # create 7z archive file

--- a/create_msys2_pkg.rb
+++ b/create_msys2_pkg.rb
@@ -126,13 +126,10 @@ module CreateMSYS2Tools
       exec_check "Keep the newest for all other packages" , "#{BASH} -c \"paccache -r -f -k1\""
       exec_check "Remove all cached packages" , "#{PACMAN} -Scc --noconfirm"
 
-      # create a delta package for existing mysys installation on the runner
-      if File.exist?(ORIG_MSYS2)
-        remove_non_msys2
-        remove_duplicate_files
-        clean_database 'msys'
-        clean_packages
-      end
+      remove_non_msys2
+      remove_duplicate_files if File.exist?(ORIG_MSYS2)
+      clean_database 'msys'
+      clean_packages
 
       # create 7z file
       STDOUT.syswrite "##[group]#{YEL}Create msys2 7z file#{RST}\n"


### PR DESCRIPTION
This PR is the prerequisite for: https://github.com/ruby/setup-ruby/pull/750

The complication here is that `windows-11-arm` runner does not have msys2 preinstalled, so that we have to create a full msys2 package, instead of the current partial update package.

Following the naming convention of ruby-builder, the partial package is named `msys2-windows-latest`, and the full package is named `msys2-windows-11-arm64`.

Another tricky problem is the chicken and egg problem that this PR depends on updated setup-ruby in order to run ruby script on `windows-11-arm`, while the `setup-ruby` also depends on the artifacts here. So currently this PR is pointing to my fork of setup-ruby, which download msys2 from my fork of setup-msys2-gcc. We can update this later once this is merged and a working build is available in this repo.